### PR TITLE
Fix error wasm-bindgen about ssvmup.

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -303,7 +303,11 @@ impl<'a> Context<'a> {
             "
             import * as path from 'https://deno.land/std/path/mod.ts';
             import WASI from 'https://deno.land/std/wasi/snapshot_preview1.ts';
-            const __dirname = path.dirname(new URL(import.meta.url).pathname);
+            import {{ isWindows }} from 'https://deno.land/std/_util/os.ts';
+            let __dirname = path.dirname(new URL(import.meta.url).pathname);
+            if (isWindows) {{
+                __dirname = __dirname.substring(1);
+            }}
             const wasi = new WASI({{
                 args: Deno.args,
                 env: Deno.env.toObject(),


### PR DESCRIPTION
Based on [Release 0.2.61+ssvm.19](https://github.com/second-state/wasm-bindgen/releases/tag/0.2.61%2Bssvm.19)

An error occurred when running `ssvmup build --target deno` on Windows 10. So I added the code to `wasm-bindgen/cli-support`. Please check the other code.